### PR TITLE
Release v2 to use the new installer

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,31 +1,90 @@
 version: 2.1
 orbs:
   autify-cli: autify/autify-cli@dev:<<pipeline.git.revision>>
+  node: circleci/node@5
   orb-tools: circleci/orb-tools@11.1
 
 filters: &filters
   tags:
     only: /.*/
 
+executors:
+  windows:
+    machine:
+      resource_class: 'windows.medium'
+      image: windows-server-2022-gui:current
+  macos:
+    macos:
+      xcode: 14.0.0
+
 jobs:
   # Create a job to test the commands of your orbs.
   # You may want to add additional validation steps to ensure the commands are working as expected.
-  command-tests:
-    executor: autify-cli/default
+  default-tests:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    shell: bash
     steps:
-      - checkout
-      # Run your orb's commands to validate them.
       - autify-cli/install
       - run: autify --version
+      - run: echo token | autify web auth login
+      - run: echo token | autify mobile auth login
+      - run: autify connect client install
+
+  specific-tests:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    shell: bash
+    steps:
       - autify-cli/install:
-          version: 0.1.0
-      - run: autify --version
+          shell-installer-url: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
+      - run: autify --version | grep beta
+      - run: echo token | autify web auth login
+      - run: echo token | autify mobile auth login
+      - run: autify connect client install
+
+  integration-tests:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    shell: bash
+    environment:
+      AUTIFY_CLI_INTEGRATION_TEST_INSTALL: 1
+      AUTIFY_CONNECT_CLIENT_MODE: fake
+    steps:
+      - node/install:
+          node-version: 16.17.0
+      - run: nvm use 16.17.0
+      - autify-cli/install
+      - run: echo token | autify web auth login
+      - run: echo token | autify mobile auth login
+      - run: autify connect client install
+      - run: autify-cli-integration-test
+
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - command-tests:
+      - default-tests:
           filters: *filters
+          matrix:
+            parameters:
+              os: [autify-cli/default, macos, windows]
+      - specific-tests:
+          filters: *filters
+          matrix:
+            parameters:
+              os: [autify-cli/default, macos, windows]
+      - integration-tests:
+          filters: *filters
+          matrix:
+            parameters:
+              os: [autify-cli/default, macos, windows]
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -34,7 +93,9 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - command-tests
+            - default-tests
+            - specific-tests
+            - integration-tests
           context: orb-publishing
           filters:
             branches:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -2,14 +2,16 @@ description: >
   Install Autify Command Line Interface (CLI).
 
 parameters:
-  version:
+  shell-installer-url:
     type: string
-    default: stable
+    # TODO: Use stable
+    default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
     description: "Install version"
 
 steps:
   - run:
       environment:
-        PARAM_VERSION: <<parameters.version>>
+        PARAM_SHELL_INSTALLER_URL: <<parameters.shell-installer-url>>
       name: Install Autify CLI
+      shell: bash -xe
       command: <<include(scripts/install.sh)>>

--- a/src/examples/install-autify-cli.yml
+++ b/src/examples/install-autify-cli.yml
@@ -5,13 +5,12 @@ usage:
   version: 2.1
 
   orbs:
-    autify-cli: autify/autify-cli@1
+    autify-cli: autify/autify-cli@2
 
   jobs:
     autify-cli-example:
       executor: autify-cli/default
       steps:
-        - checkout
         - autify-cli/install
         - run: autify --version
 

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -2,6 +2,7 @@ description: >
   A base Docker image should work.
 docker:
   - image: 'cimg/base:<<parameters.tag>>'
+resource_class: <<parameters.size>>
 parameters:
   tag:
     default: current
@@ -9,3 +10,7 @@ parameters:
       Pick a specific cimg/base image variant:
       https://hub.docker.com/r/cimg/base/tags
     type: string
+  size:
+    default: small
+    type: string
+    description: Dokcer executer's resource_class

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-curl https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-standalone.sh | bash
+set -xe
 
-if [ "$PARAM_VERSION" != "stable" ]; then
-  autify update -v "$PARAM_VERSION"
-fi
+: "${PARAM_SHELL_INSTALLER_URL:?"Provide the installer URL"}"
+
+cd "${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}"
+export AUTIFY_CLI_INSTALL_USE_CACHE=1
+curl -L "$PARAM_SHELL_INSTALLER_URL" | bash -xe
+
+while IFS= read -r line; do
+  echo "export PATH=$line:\$PATH" >> "$BASH_ENV"
+done < "./autify/path"


### PR DESCRIPTION
We decide to centralize the CLI installation.

Also, opening a way to inject any specific installer which helps our integration tests.