### PR TITLE
[PLAT-406] chore: upgraded macOS resource_class to macos.m1.medium.gen1

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,6 +20,7 @@ executors:
   macos:
     macos:
       xcode: 14.0.0
+    resource_class: 'macos.m1.medium.gen1'
 
 jobs:
   # Create a job to test the commands of your orbs.


### PR DESCRIPTION
upgraded CircleCI macos resource class to `macos.m1.medium.gen1`

see: [Passed CI on M1 Medium](https://app.circleci.com/pipelines/github/autifyhq/autify-circleci-orb-cli/517/workflows/c1cf2a4f-40f4-4c7b-90ac-7225b729d74d/jobs/6010)