### PR TITLE
Update Linux image

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,7 +12,7 @@ executors:
   linux:
     machine:
       resource_class: "medium"
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:2024.11.1
   windows:
     machine:
       resource_class: "windows.medium"


### PR DESCRIPTION
To fix the CI failures

```
Job was rejected because resource class medium, image ubuntu-2004:202010-01 is not a valid resource class
```

![image](https://github.com/user-attachments/assets/1ee33aea-f72e-4402-bee8-a59464b76fb4)

https://app.circleci.com/pipelines/github/autifyhq/autify-circleci-orb-cli/947/workflows/d3571ee4-0781-4ff7-85b9-f63875f45005/jobs/10730