### PR TITLE
Update runner to m4 mac

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,8 +19,7 @@ executors:
       image: windows-server-2022-gui:current
   macos:
     macos:
-      xcode: 14.0.0
-    resource_class: 'macos.m1.medium.gen1'
+      xcode: 16.2.0
 
 jobs:
   # Create a job to test the commands of your orbs.

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -98,7 +98,7 @@ workflows:
             parameters:
               os: [linux, macos, windows]
           shell-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash
-          node-version: 18.14.2
+          node-version: 22.21.1
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -126,7 +126,7 @@ workflows:
             parameters:
               os: [linux, macos, windows]
           shell-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash
-          node-version: 18.14.2
+          node-version: 22.21.1
   nightly-beta-test:
     when:
       equal: [scheduled_pipeline, << pipeline.trigger_source >>]
@@ -137,4 +137,4 @@ workflows:
             parameters:
               os: [linux, macos, windows]
           shell-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash
-          node-version: 18.14.2
+          node-version: 22.21.1


### PR DESCRIPTION
Updates the CircleCI runner to not pin a specific mac model, in order to avoid problems from the upcoming deprecation. (I ran the [CI with the m4 mac specified](https://app.circleci.com/pipelines/github/autifyhq/autify-circleci-orb-cli/1271/workflows/f8ed9167-76ab-4a39-9f22-7e52cbb3f98c) once to make sure it works with that one, and then removed it so that it's now unpinned, since the default won't automatically update to `m4` until December according to the announcement email.)

Also fixed the integration tests so I could verify the new runner worked, since a change in the autify-cli integration tests package required a newer node version.

https://github.com/autifyhq/autify-cli/commit/b9cf9752ac16bc350b97fc8fbb7f00eb6c3c1322#diff-ac486df74e94bc056f8439f355fb83d5353b42e3cb80daa984800088ad943c32R18